### PR TITLE
Pass content-type through when proxying

### DIFF
--- a/proxy-server/fusion-proxy.js
+++ b/proxy-server/fusion-proxy.js
@@ -32,6 +32,7 @@ function onRequest(client_req, client_res) {
 
 
     var proxy = http.request(options, function (res) {
+        client_res.setHeader('Content-Type', res.headers['content-type']);
         res.pipe(client_res, {
             end: true
         });


### PR DESCRIPTION
Some client libs expect a content-type header.  This patch includes it when proxying.
